### PR TITLE
Feat/todo #15 투두리스트 및 카테고리 API

### DIFF
--- a/mogakco/src/main/java/project/mogakco/domain/member/application/impl/MemberServiceImpl.java
+++ b/mogakco/src/main/java/project/mogakco/domain/member/application/impl/MemberServiceImpl.java
@@ -22,4 +22,8 @@ public class MemberServiceImpl {
 	public MemberSocial getMemberInfoByAuthToken(String authToken){
 		return memberRepository.findByAuthToken(authToken).get();
 	}
+
+	public MemberSocial getMemberInfoByOAuthId(String oauthId){
+		return memberRepository.findByOauthId(oauthId).orElse(null);
+	}
 }

--- a/mogakco/src/main/java/project/mogakco/domain/member/entity/member/MemberSocial.java
+++ b/mogakco/src/main/java/project/mogakco/domain/member/entity/member/MemberSocial.java
@@ -3,6 +3,7 @@ package project.mogakco.domain.member.entity.member;
 import lombok.*;
 import project.mogakco.domain.member.dto.MemberDTO;
 import project.mogakco.domain.timer.entity.Timer;
+import project.mogakco.domain.todo.entity.ToDo;
 import project.mogakco.global.domain.BaseEntity;
 
 import javax.persistence.*;
@@ -38,6 +39,9 @@ public class MemberSocial extends BaseEntity {
 	private String refreshToken;
 
 	private String password;
+
+	@OneToMany(fetch = FetchType.LAZY,mappedBy = "")
+	private List<ToDo> toDoList;
 
 	@OneToMany(fetch = FetchType.LAZY,mappedBy = "memberSocial")
 	private List<Timer> timer;

--- a/mogakco/src/main/java/project/mogakco/domain/member/entity/member/MemberSocial.java
+++ b/mogakco/src/main/java/project/mogakco/domain/member/entity/member/MemberSocial.java
@@ -40,7 +40,7 @@ public class MemberSocial extends BaseEntity {
 
 	private String password;
 
-	@OneToMany(fetch = FetchType.LAZY,mappedBy = "")
+	@OneToMany(fetch = FetchType.LAZY,mappedBy = "memberSocial")
 	private List<ToDo> toDoList;
 
 	@OneToMany(fetch = FetchType.LAZY,mappedBy = "memberSocial")

--- a/mogakco/src/main/java/project/mogakco/domain/member/entity/member/MemberSocial.java
+++ b/mogakco/src/main/java/project/mogakco/domain/member/entity/member/MemberSocial.java
@@ -3,6 +3,7 @@ package project.mogakco.domain.member.entity.member;
 import lombok.*;
 import project.mogakco.domain.member.dto.MemberDTO;
 import project.mogakco.domain.timer.entity.Timer;
+import project.mogakco.domain.todo.entity.Category;
 import project.mogakco.domain.todo.entity.ToDo;
 import project.mogakco.global.domain.BaseEntity;
 
@@ -48,6 +49,9 @@ public class MemberSocial extends BaseEntity {
 	public void updateRefreshToken(String updateRefreshToken){
 		this.refreshToken=updateRefreshToken;
 	}
+
+	@OneToMany(fetch = FetchType.LAZY,mappedBy = "memberSocial")
+	public List<Category> categories;
 
 	public MemberSocial updateOAuthInfo(MemberDTO.UpdateOAuthUser updateOAuthUser){
 		this.authToken=updateOAuthUser.getAuthToken();

--- a/mogakco/src/main/java/project/mogakco/domain/todo/api/CategoryAPIController.java
+++ b/mogakco/src/main/java/project/mogakco/domain/todo/api/CategoryAPIController.java
@@ -1,0 +1,26 @@
+package project.mogakco.domain.todo.api;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+import project.mogakco.domain.member.application.impl.MemberServiceImpl;
+import project.mogakco.domain.todo.application.service.category.CategoryService;
+import project.mogakco.global.dto.requset.MemberInfoDTO;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/v1/category")
+public class CategoryAPIController {
+
+	private final MemberServiceImpl memberService;
+
+	private final CategoryService categoryService;
+
+	@GetMapping()
+	public void getCategoryListInfo(@RequestBody MemberInfoDTO.selectInfoByoauthIdDTO selectInfoByoauthIdDTO){
+		categoryService.getListOfCategory(memberService.getMemberInfoByOAuthId(selectInfoByoauthIdDTO.getOauthId()));
+	}
+}

--- a/mogakco/src/main/java/project/mogakco/domain/todo/api/CategoryAPIController.java
+++ b/mogakco/src/main/java/project/mogakco/domain/todo/api/CategoryAPIController.java
@@ -1,14 +1,17 @@
 package project.mogakco.domain.todo.api;
 
 import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 import project.mogakco.domain.member.application.impl.MemberServiceImpl;
 import project.mogakco.domain.todo.application.service.category.CategoryService;
+import project.mogakco.domain.todo.dto.request.CategoryDTO;
+import project.mogakco.domain.todo.dto.request.ToDoDTO;
+import project.mogakco.domain.todo.entity.Category;
 import project.mogakco.global.dto.requset.MemberInfoDTO;
+
+import java.util.List;
 
 @RestController
 @RequiredArgsConstructor
@@ -19,8 +22,28 @@ public class CategoryAPIController {
 
 	private final CategoryService categoryService;
 
-	@GetMapping()
-	public void getCategoryListInfo(@RequestBody MemberInfoDTO.selectInfoByoauthIdDTO selectInfoByoauthIdDTO){
-		categoryService.getListOfCategory(memberService.getMemberInfoByOAuthId(selectInfoByoauthIdDTO.getOauthId()));
+	@GetMapping
+	public ResponseEntity<List<Category>> getCategoryListInfo(@RequestBody MemberInfoDTO.selectInfoByoauthIdDTO selectInfoByoauthIdDTO){
+		List<Category> listOfCategory = categoryService.getListOfCategory(memberService.getMemberInfoByOAuthId(selectInfoByoauthIdDTO.getOauthId()));
+		return new ResponseEntity<>(listOfCategory, HttpStatus.OK);
+	}
+
+	@PostMapping
+	public ResponseEntity<?> createCategorayByName(@RequestBody CategoryDTO.CategoryCreateDTO categoryCreateDTO){
+		Category createdCategory
+				= categoryService.createCategoryOne(categoryCreateDTO);
+		return new ResponseEntity<>(createdCategory,HttpStatus.OK);
+	}
+
+	@PutMapping
+	public ResponseEntity<?> changCategoryName(@RequestBody CategoryDTO.ChangeNameDTO changeNameDTO){
+		Category changeCategorayName =
+				categoryService.changeCategorayName(changeNameDTO);
+		return new ResponseEntity<>(changeCategorayName,HttpStatus.OK);
+	}
+
+	@DeleteMapping
+	public ResponseEntity<?> eliminateCategory(@RequestBody CategoryDTO.EliminateDTO eliminateDTO){
+		return categoryService.eliminateCategory(eliminateDTO);
 	}
 }

--- a/mogakco/src/main/java/project/mogakco/domain/todo/api/ToDoAPIController.java
+++ b/mogakco/src/main/java/project/mogakco/domain/todo/api/ToDoAPIController.java
@@ -1,0 +1,43 @@
+package project.mogakco.domain.todo.api;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.log4j.Log4j2;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+import project.mogakco.domain.todo.application.service.todo.ToDoService;
+import project.mogakco.domain.todo.dto.request.ToDoDTO;
+import project.mogakco.domain.todo.entity.ToDo;
+
+@RestController
+@RequiredArgsConstructor
+@Log4j2
+@RequestMapping("/api/v1/todo")
+public class ToDoAPIController {
+
+	private final ToDoService toDoService;
+
+	@PostMapping
+	public ResponseEntity<?> createOneTodoTap(@RequestBody ToDoDTO.ToDoCreateDTO toDoCreateDTO){
+		ToDo createTodo = toDoService.createOneToDoTap(toDoCreateDTO);
+		return new ResponseEntity<>(createTodo, HttpStatus.OK);
+	}
+
+	@PostMapping("/contents")
+	public ResponseEntity<?> writeContents(@RequestBody ToDoDTO.ToDoWriteContentsDTO writeContentsDTO){
+		ToDo writeToDO = toDoService.writeContentsOneToDoTap(writeContentsDTO);
+		return new ResponseEntity<>(writeContentsDTO,HttpStatus.OK);
+	}
+
+	@PutMapping
+	public ResponseEntity<?> changeTitleTodo(@RequestBody ToDoDTO.ChangTitleDTO changTitleDTO){
+		ToDo changeTitle = toDoService.changeTitleTodo(changTitleDTO);
+		return new ResponseEntity<>(changeTitle,HttpStatus.OK);
+	}
+
+	@DeleteMapping
+	public ResponseEntity<?> eliminate(@RequestBody ToDoDTO.ToDoEliminateDTO eliminateDTO){
+		return toDoService.eliminateOneToDoTap(eliminateDTO);
+	}
+
+}

--- a/mogakco/src/main/java/project/mogakco/domain/todo/application/impl/category/CategoryServiceImpl.java
+++ b/mogakco/src/main/java/project/mogakco/domain/todo/application/impl/category/CategoryServiceImpl.java
@@ -2,16 +2,21 @@ package project.mogakco.domain.todo.application.impl.category;
 
 import lombok.RequiredArgsConstructor;
 import lombok.extern.log4j.Log4j2;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+import project.mogakco.domain.member.application.impl.MemberServiceImpl;
 import project.mogakco.domain.member.entity.member.MemberSocial;
 import project.mogakco.domain.todo.application.service.category.CategoryService;
+import project.mogakco.domain.todo.dto.request.CategoryDTO;
 import project.mogakco.domain.todo.entity.Category;
 import project.mogakco.domain.todo.repo.CategoryRepository;
 
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
+import java.util.Optional;
 
 @Service
 @Log4j2
@@ -23,12 +28,15 @@ public class CategoryServiceImpl implements CategoryService {
 
 	private final CategoryRepository categoryRepository;
 
+	private final MemberServiceImpl memberService;
+
 	@Override
 	@Transactional
-	public Category createCategoryOne(String category_name) {
+	public Category createCategoryOne(CategoryDTO.CategoryCreateDTO categoryCreateDTO) {
 		return categoryRepository.save(
 				Category.builder()
-						.categoryName(category_name)
+						.memberSocial(memberService.getMemberInfoByOAuthId(categoryCreateDTO.getOauthId()))
+						.categoryName(categoryCreateDTO.getCategory_name())
 						.build()
 		);
 
@@ -65,6 +73,29 @@ public class CategoryServiceImpl implements CategoryService {
 	@Override
 	public boolean getCategoryInfoNameAndMember(MemberSocial memberSocial) {
 		return categoryRepository.findByCategoryNameAndMemberSocial("ToDo",memberSocial).isEmpty();
+	}
+
+	@Override
+	@Transactional
+	public Category changeCategorayName(CategoryDTO.ChangeNameDTO changeNameDTO) {
+		return categoryRepository.findByCategoryNameAndMemberSocial(changeNameDTO.getCategoryOwn(),
+						memberService.getMemberInfoByOAuthId(changeNameDTO.getOauthId()))
+						.get()
+							.changeCategoryName(changeNameDTO.getCategoryGeu());
+	}
+
+	@Override
+	@Transactional
+	public ResponseEntity<?> eliminateCategory(CategoryDTO.EliminateDTO eliminateDTO) {
+		Optional<Category> findC = categoryRepository.findByCategoryNameAndMemberSocial(eliminateDTO.getCategoryName(),
+				memberService.getMemberInfoByOAuthId(eliminateDTO.getOauthId()));
+
+		if (findC.isPresent()){
+			categoryRepository.delete(findC.get());
+			return new ResponseEntity<>("Category Delete", HttpStatus.OK);
+		}else {
+			return new ResponseEntity<>("Bad Req",HttpStatus.BAD_REQUEST);
+		}
 	}
 
 }

--- a/mogakco/src/main/java/project/mogakco/domain/todo/application/impl/category/CategoryServiceImpl.java
+++ b/mogakco/src/main/java/project/mogakco/domain/todo/application/impl/category/CategoryServiceImpl.java
@@ -1,0 +1,43 @@
+package project.mogakco.domain.todo.application.impl.category;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.log4j.Log4j2;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import project.mogakco.domain.todo.application.service.category.CategoryService;
+import project.mogakco.domain.todo.entity.Category;
+import project.mogakco.domain.todo.repo.CategoryRepository;
+
+import java.util.List;
+import java.util.Optional;
+
+@Service
+@Log4j2
+@Transactional
+@RequiredArgsConstructor
+public class CategoryServiceImpl implements CategoryService {
+
+	private final CategoryRepository categoryRepository;
+
+	@Override
+	public Category createCategoryOne(String category_name) {
+		return categoryRepository.save(
+				Category.builder()
+						.category_name(category_name)
+						.build()
+		);
+
+	}
+
+	@Override
+	public List<Category> getListOfCategory() {
+		return categoryRepository.findAll();
+	}
+
+	@Override
+	public Category getCategoryInfoName(String category_name) {
+		return categoryRepository.findByCategory_name(category_name).orElse(null);
+	}
+}

--- a/mogakco/src/main/java/project/mogakco/domain/todo/application/impl/category/CategoryServiceImpl.java
+++ b/mogakco/src/main/java/project/mogakco/domain/todo/application/impl/category/CategoryServiceImpl.java
@@ -2,42 +2,69 @@ package project.mogakco.domain.todo.application.impl.category;
 
 import lombok.RequiredArgsConstructor;
 import lombok.extern.log4j.Log4j2;
-import org.springframework.http.HttpStatus;
-import org.springframework.http.ResponseEntity;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+import project.mogakco.domain.member.entity.member.MemberSocial;
 import project.mogakco.domain.todo.application.service.category.CategoryService;
 import project.mogakco.domain.todo.entity.Category;
 import project.mogakco.domain.todo.repo.CategoryRepository;
 
+import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.List;
-import java.util.Optional;
 
 @Service
 @Log4j2
-@Transactional
+@Transactional(readOnly = true)
 @RequiredArgsConstructor
 public class CategoryServiceImpl implements CategoryService {
+
+	private final ArrayList<String> basicCategories= new ArrayList<>(Arrays.asList("ToDo","Doing","Done"));
 
 	private final CategoryRepository categoryRepository;
 
 	@Override
+	@Transactional
 	public Category createCategoryOne(String category_name) {
 		return categoryRepository.save(
 				Category.builder()
-						.category_name(category_name)
+						.categoryName(category_name)
 						.build()
 		);
 
 	}
 
 	@Override
-	public List<Category> getListOfCategory() {
-		return categoryRepository.findAll();
+	public List<Category> getListOfCategory(MemberSocial memberSocial) {
+		List<Category> findByMemberInfoCategoryList=new ArrayList<>();
+		for (Category category:categoryRepository.findAll()){
+			if (category.getMemberSocial().equals(memberSocial)) findByMemberInfoCategoryList.add(category);
+		}
+
+		return findByMemberInfoCategoryList;
 	}
 
 	@Override
 	public Category getCategoryInfoName(String category_name) {
-		return categoryRepository.findByCategory_name(category_name).orElse(null);
+		return categoryRepository.findByCategoryName(category_name).orElse(null);
 	}
+
+	@Override
+	@Transactional
+	public void initializeBasicCategory(MemberSocial member) {
+		for (String category:basicCategories){
+			categoryRepository.save(
+					Category.builder()
+							.categoryName(category)
+							.memberSocial(member)
+							.build()
+			);
+		}
+	}
+
+	@Override
+	public boolean getCategoryInfoNameAndMember(MemberSocial memberSocial) {
+		return categoryRepository.findByCategoryNameAndMemberSocial("ToDo",memberSocial).isEmpty();
+	}
+
 }

--- a/mogakco/src/main/java/project/mogakco/domain/todo/application/impl/todo/ToDoServiceImpl.java
+++ b/mogakco/src/main/java/project/mogakco/domain/todo/application/impl/todo/ToDoServiceImpl.java
@@ -28,10 +28,11 @@ public class ToDoServiceImpl implements ToDoService {
 	private final MemberServiceImpl memberService;
 
 	@Transactional
+	@Override
 	public ToDo createOneToDoTap(ToDoDTO.ToDoCreateDTO toDoCreateDTO){
 		return toDoRepository.save(
 				ToDo.builder()
-						.todo_title(toDoCreateDTO.getTodo_title())
+						.todoTitle(toDoCreateDTO.getTodo_title())
 						.category(categoryService.getCategoryInfoName(toDoCreateDTO.getCategory_name()))
 						.memberSocial(memberService.getMemberInfoByOAuthId(toDoCreateDTO.getOauthId()))
 						.build()
@@ -39,6 +40,7 @@ public class ToDoServiceImpl implements ToDoService {
 	}
 
 	@Transactional
+	@Override
 	public ToDo writeContentsOneToDoTap(ToDoDTO.ToDoWriteContentsDTO toDoWriteContentsDTO){
 		return toDoRepository.findByTodoSeqAndMemberSocial(toDoWriteContentsDTO.getTodoSeq(),
 						memberService.getMemberInfoByOAuthId(toDoWriteContentsDTO.getOauthId()))
@@ -47,6 +49,7 @@ public class ToDoServiceImpl implements ToDoService {
 	}
 
 	@Transactional
+	@Override
 	public ResponseEntity<?> eliminateOneToDoTap(ToDoDTO.ToDoEliminateDTO toDoEliminateDTO){
 		Optional<ToDo> findT =
 				toDoRepository.findByTodoSeqAndMemberSocial(
@@ -60,6 +63,18 @@ public class ToDoServiceImpl implements ToDoService {
 		}else {
 			return new ResponseEntity<>("Bad sequence",HttpStatus.BAD_REQUEST);
 		}
+	}
+
+	@Override
+	@Transactional
+	public ToDo changeTitleTodo(ToDoDTO.ChangTitleDTO changTitleDTO) {
+		Optional<ToDo> findT =
+				toDoRepository.findByTodoSeqAndMemberSocial(
+						changTitleDTO.getTodoSeq(),
+						memberService.getMemberInfoByOAuthId(changTitleDTO.getOauthId())
+				);
+
+		return findT.map(toDo -> toDo.changeTitleTodo(changTitleDTO.getChangeTitle())).orElse(null);
 	}
 
 

--- a/mogakco/src/main/java/project/mogakco/domain/todo/application/impl/todo/ToDoServiceImpl.java
+++ b/mogakco/src/main/java/project/mogakco/domain/todo/application/impl/todo/ToDoServiceImpl.java
@@ -2,6 +2,8 @@ package project.mogakco.domain.todo.application.impl.todo;
 
 import lombok.RequiredArgsConstructor;
 import lombok.extern.log4j.Log4j2;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import project.mogakco.domain.member.application.impl.MemberServiceImpl;
@@ -10,6 +12,8 @@ import project.mogakco.domain.todo.application.service.todo.ToDoService;
 import project.mogakco.domain.todo.dto.request.ToDoDTO;
 import project.mogakco.domain.todo.entity.ToDo;
 import project.mogakco.domain.todo.repo.ToDoRepository;
+
+import java.util.Optional;
 
 @Service
 @Log4j2
@@ -34,7 +38,22 @@ public class ToDoServiceImpl implements ToDoService {
 		);
 	}
 
-	public ToDo writeContentsOneToDoTap(Long todo_seq,String write_contents){
-		return toDoRepository.findById(todo_seq).get().writeContents(write_contents);
+	@Transactional
+	public ToDo writeContentsOneToDoTap(ToDoDTO.ToDoWriteContentsDTO toDoWriteContentsDTO){
+		return toDoRepository.findById(toDoWriteContentsDTO.getTodo_seq()).get().writeContents(toDoWriteContentsDTO.getTodo_contents());
 	}
+
+	@Transactional
+	public ResponseEntity<?> eliminateOneToDoTap(ToDoDTO.ToDoEliminateDTO toDoEliminateDTO){
+		Optional<ToDo> findT =
+				toDoRepository.findById(toDoEliminateDTO.getTodo_seq());
+
+		if (findT.isPresent()){
+			toDoRepository.delete(findT.get());
+			return new ResponseEntity<>("todo_eliminate", HttpStatus.OK);
+		}else {
+			return new ResponseEntity<>("Bad sequence",HttpStatus.BAD_REQUEST);
+		}
+	}
+
 }

--- a/mogakco/src/main/java/project/mogakco/domain/todo/application/impl/todo/ToDoServiceImpl.java
+++ b/mogakco/src/main/java/project/mogakco/domain/todo/application/impl/todo/ToDoServiceImpl.java
@@ -28,25 +28,31 @@ public class ToDoServiceImpl implements ToDoService {
 	private final MemberServiceImpl memberService;
 
 	@Transactional
-	public ToDo createOneToDoTap(ToDoDTO.ToDoCreateDTO toDoCreateDTO, String oauthId){
+	public ToDo createOneToDoTap(ToDoDTO.ToDoCreateDTO toDoCreateDTO){
 		return toDoRepository.save(
 				ToDo.builder()
 						.todo_title(toDoCreateDTO.getTodo_title())
 						.category(categoryService.getCategoryInfoName(toDoCreateDTO.getCategory_name()))
-						.memberSocial(memberService.getMemberInfoByOAuthId(oauthId))
+						.memberSocial(memberService.getMemberInfoByOAuthId(toDoCreateDTO.getOauthId()))
 						.build()
 		);
 	}
 
 	@Transactional
 	public ToDo writeContentsOneToDoTap(ToDoDTO.ToDoWriteContentsDTO toDoWriteContentsDTO){
-		return toDoRepository.findById(toDoWriteContentsDTO.getTodo_seq()).get().writeContents(toDoWriteContentsDTO.getTodo_contents());
+		return toDoRepository.findByTodoSeqAndMemberSocial(toDoWriteContentsDTO.getTodoSeq(),
+						memberService.getMemberInfoByOAuthId(toDoWriteContentsDTO.getOauthId()))
+							.get()
+								.writeContents(toDoWriteContentsDTO.getTodo_contents());
 	}
 
 	@Transactional
 	public ResponseEntity<?> eliminateOneToDoTap(ToDoDTO.ToDoEliminateDTO toDoEliminateDTO){
 		Optional<ToDo> findT =
-				toDoRepository.findById(toDoEliminateDTO.getTodo_seq());
+				toDoRepository.findByTodoSeqAndMemberSocial(
+						toDoEliminateDTO.getTodoSeq(),
+						memberService.getMemberInfoByOAuthId(toDoEliminateDTO.getOauthId())
+				);
 
 		if (findT.isPresent()){
 			toDoRepository.delete(findT.get());
@@ -55,5 +61,6 @@ public class ToDoServiceImpl implements ToDoService {
 			return new ResponseEntity<>("Bad sequence",HttpStatus.BAD_REQUEST);
 		}
 	}
+
 
 }

--- a/mogakco/src/main/java/project/mogakco/domain/todo/application/impl/todo/ToDoServiceImpl.java
+++ b/mogakco/src/main/java/project/mogakco/domain/todo/application/impl/todo/ToDoServiceImpl.java
@@ -1,0 +1,40 @@
+package project.mogakco.domain.todo.application.impl.todo;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.log4j.Log4j2;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import project.mogakco.domain.member.application.impl.MemberServiceImpl;
+import project.mogakco.domain.todo.application.service.category.CategoryService;
+import project.mogakco.domain.todo.application.service.todo.ToDoService;
+import project.mogakco.domain.todo.dto.request.ToDoDTO;
+import project.mogakco.domain.todo.entity.ToDo;
+import project.mogakco.domain.todo.repo.ToDoRepository;
+
+@Service
+@Log4j2
+@Transactional(readOnly = true)
+@RequiredArgsConstructor
+public class ToDoServiceImpl implements ToDoService {
+
+	private final CategoryService categoryService;
+
+	private final ToDoRepository toDoRepository;
+
+	private final MemberServiceImpl memberService;
+
+	@Transactional
+	public ToDo createOneToDoTap(ToDoDTO.ToDoCreateDTO toDoCreateDTO, String oauthId){
+		return toDoRepository.save(
+				ToDo.builder()
+						.todo_title(toDoCreateDTO.getTodo_title())
+						.category(categoryService.getCategoryInfoName(toDoCreateDTO.getCategory_name()))
+						.memberSocial(memberService.getMemberInfoByOAuthId(oauthId))
+						.build()
+		);
+	}
+
+	public ToDo writeContentsOneToDoTap(Long todo_seq,String write_contents){
+		return toDoRepository.findById(todo_seq).get().writeContents(write_contents);
+	}
+}

--- a/mogakco/src/main/java/project/mogakco/domain/todo/application/service/category/CategoryService.java
+++ b/mogakco/src/main/java/project/mogakco/domain/todo/application/service/category/CategoryService.java
@@ -1,6 +1,6 @@
 package project.mogakco.domain.todo.application.service.category;
 
-import org.springframework.http.ResponseEntity;
+import project.mogakco.domain.member.entity.member.MemberSocial;
 import project.mogakco.domain.todo.entity.Category;
 
 import java.util.List;
@@ -9,7 +9,11 @@ public interface CategoryService {
 
 	Category createCategoryOne(String category_name);
 
-	List<Category> getListOfCategory();
+	List<Category> getListOfCategory(MemberSocial memberSocial);
 
 	Category getCategoryInfoName(String category_name);
+
+	void initializeBasicCategory(MemberSocial member);
+
+	boolean getCategoryInfoNameAndMember(MemberSocial memberSocial);
 }

--- a/mogakco/src/main/java/project/mogakco/domain/todo/application/service/category/CategoryService.java
+++ b/mogakco/src/main/java/project/mogakco/domain/todo/application/service/category/CategoryService.java
@@ -1,0 +1,15 @@
+package project.mogakco.domain.todo.application.service.category;
+
+import org.springframework.http.ResponseEntity;
+import project.mogakco.domain.todo.entity.Category;
+
+import java.util.List;
+
+public interface CategoryService {
+
+	Category createCategoryOne(String category_name);
+
+	List<Category> getListOfCategory();
+
+	Category getCategoryInfoName(String category_name);
+}

--- a/mogakco/src/main/java/project/mogakco/domain/todo/application/service/category/CategoryService.java
+++ b/mogakco/src/main/java/project/mogakco/domain/todo/application/service/category/CategoryService.java
@@ -1,13 +1,15 @@
 package project.mogakco.domain.todo.application.service.category;
 
+import org.springframework.http.ResponseEntity;
 import project.mogakco.domain.member.entity.member.MemberSocial;
+import project.mogakco.domain.todo.dto.request.CategoryDTO;
 import project.mogakco.domain.todo.entity.Category;
 
 import java.util.List;
 
 public interface CategoryService {
 
-	Category createCategoryOne(String category_name);
+	Category createCategoryOne(CategoryDTO.CategoryCreateDTO categoryCreateDTO);
 
 	List<Category> getListOfCategory(MemberSocial memberSocial);
 
@@ -16,4 +18,8 @@ public interface CategoryService {
 	void initializeBasicCategory(MemberSocial member);
 
 	boolean getCategoryInfoNameAndMember(MemberSocial memberSocial);
+
+	Category changeCategorayName(CategoryDTO.ChangeNameDTO changeNameDTO);
+
+	ResponseEntity<?> eliminateCategory(CategoryDTO.EliminateDTO eliminateDTO);
 }

--- a/mogakco/src/main/java/project/mogakco/domain/todo/application/service/todo/ToDoService.java
+++ b/mogakco/src/main/java/project/mogakco/domain/todo/application/service/todo/ToDoService.java
@@ -1,5 +1,6 @@
 package project.mogakco.domain.todo.application.service.todo;
 
+import org.springframework.http.ResponseEntity;
 import project.mogakco.domain.todo.dto.request.ToDoDTO;
 import project.mogakco.domain.todo.entity.ToDo;
 
@@ -7,5 +8,7 @@ public interface ToDoService {
 
 	ToDo createOneToDoTap(ToDoDTO.ToDoCreateDTO toDoCreateDTO, String oauthId);
 
+	ToDo writeContentsOneToDoTap(ToDoDTO.ToDoWriteContentsDTO toDoWriteContentsDTO);
 
+	ResponseEntity<?> eliminateOneToDoTap(ToDoDTO.ToDoEliminateDTO toDoEliminateDTO);
 }

--- a/mogakco/src/main/java/project/mogakco/domain/todo/application/service/todo/ToDoService.java
+++ b/mogakco/src/main/java/project/mogakco/domain/todo/application/service/todo/ToDoService.java
@@ -6,7 +6,7 @@ import project.mogakco.domain.todo.entity.ToDo;
 
 public interface ToDoService {
 
-	ToDo createOneToDoTap(ToDoDTO.ToDoCreateDTO toDoCreateDTO, String oauthId);
+	ToDo createOneToDoTap(ToDoDTO.ToDoCreateDTO toDoCreateDTO);
 
 	ToDo writeContentsOneToDoTap(ToDoDTO.ToDoWriteContentsDTO toDoWriteContentsDTO);
 

--- a/mogakco/src/main/java/project/mogakco/domain/todo/application/service/todo/ToDoService.java
+++ b/mogakco/src/main/java/project/mogakco/domain/todo/application/service/todo/ToDoService.java
@@ -4,6 +4,8 @@ import org.springframework.http.ResponseEntity;
 import project.mogakco.domain.todo.dto.request.ToDoDTO;
 import project.mogakco.domain.todo.entity.ToDo;
 
+import java.util.List;
+
 public interface ToDoService {
 
 	ToDo createOneToDoTap(ToDoDTO.ToDoCreateDTO toDoCreateDTO);
@@ -11,4 +13,6 @@ public interface ToDoService {
 	ToDo writeContentsOneToDoTap(ToDoDTO.ToDoWriteContentsDTO toDoWriteContentsDTO);
 
 	ResponseEntity<?> eliminateOneToDoTap(ToDoDTO.ToDoEliminateDTO toDoEliminateDTO);
+
+	ToDo changeTitleTodo(ToDoDTO.ChangTitleDTO changTitleDTO);
 }

--- a/mogakco/src/main/java/project/mogakco/domain/todo/application/service/todo/ToDoService.java
+++ b/mogakco/src/main/java/project/mogakco/domain/todo/application/service/todo/ToDoService.java
@@ -1,0 +1,11 @@
+package project.mogakco.domain.todo.application.service.todo;
+
+import project.mogakco.domain.todo.dto.request.ToDoDTO;
+import project.mogakco.domain.todo.entity.ToDo;
+
+public interface ToDoService {
+
+	ToDo createOneToDoTap(ToDoDTO.ToDoCreateDTO toDoCreateDTO, String oauthId);
+
+
+}

--- a/mogakco/src/main/java/project/mogakco/domain/todo/dto/request/CategoryDTO.java
+++ b/mogakco/src/main/java/project/mogakco/domain/todo/dto/request/CategoryDTO.java
@@ -1,0 +1,26 @@
+package project.mogakco.domain.todo.dto.request;
+
+import lombok.Getter;
+
+@Getter
+public class CategoryDTO {
+
+	@Getter
+	public static class CategoryCreateDTO{
+		private String oauthId;
+		private String category_name;
+	}
+
+	@Getter
+	public static class ChangeNameDTO{
+		private String oauthId;
+		private String categoryOwn;
+		private String categoryGeu;
+	}
+
+	@Getter
+	public static class EliminateDTO{
+		private String oauthId;
+		private String categoryName;
+	}
+}

--- a/mogakco/src/main/java/project/mogakco/domain/todo/dto/request/ToDoDTO.java
+++ b/mogakco/src/main/java/project/mogakco/domain/todo/dto/request/ToDoDTO.java
@@ -1,0 +1,14 @@
+package project.mogakco.domain.todo.dto.request;
+
+import lombok.Getter;
+import lombok.Setter;
+
+@Getter
+public class ToDoDTO {
+
+	@Getter
+	public static class ToDoCreateDTO{
+		private String todo_title;
+		private String category_name;
+	}
+}

--- a/mogakco/src/main/java/project/mogakco/domain/todo/dto/request/ToDoDTO.java
+++ b/mogakco/src/main/java/project/mogakco/domain/todo/dto/request/ToDoDTO.java
@@ -15,12 +15,14 @@ public class ToDoDTO {
 
 	@Getter
 	public static class ToDoWriteContentsDTO{
-		private Long todo_seq;
+		private Long todoSeq;
 		private String todo_contents;
+		private String oauthId;
 	}
 
 	@Getter
 	public static class ToDoEliminateDTO {
-		private Long todo_seq;
+		private Long todoSeq;
+		private String oauthId;
 	}
 }

--- a/mogakco/src/main/java/project/mogakco/domain/todo/dto/request/ToDoDTO.java
+++ b/mogakco/src/main/java/project/mogakco/domain/todo/dto/request/ToDoDTO.java
@@ -11,4 +11,15 @@ public class ToDoDTO {
 		private String todo_title;
 		private String category_name;
 	}
+
+	@Getter
+	public static class ToDoWriteContentsDTO{
+		private Long todo_seq;
+		private String todo_contents;
+	}
+
+	@Getter
+	public static class ToDoEliminateDTO {
+		private Long todo_seq;
+	}
 }

--- a/mogakco/src/main/java/project/mogakco/domain/todo/dto/request/ToDoDTO.java
+++ b/mogakco/src/main/java/project/mogakco/domain/todo/dto/request/ToDoDTO.java
@@ -8,6 +8,7 @@ public class ToDoDTO {
 
 	@Getter
 	public static class ToDoCreateDTO{
+		private String oauthId;
 		private String todo_title;
 		private String category_name;
 	}

--- a/mogakco/src/main/java/project/mogakco/domain/todo/dto/request/ToDoDTO.java
+++ b/mogakco/src/main/java/project/mogakco/domain/todo/dto/request/ToDoDTO.java
@@ -25,4 +25,11 @@ public class ToDoDTO {
 		private Long todoSeq;
 		private String oauthId;
 	}
+
+	@Getter
+	public static class ChangTitleDTO {
+		private Long todoSeq;
+		private String oauthId;
+		private String changeTitle;
+	}
 }

--- a/mogakco/src/main/java/project/mogakco/domain/todo/entity/Category.java
+++ b/mogakco/src/main/java/project/mogakco/domain/todo/entity/Category.java
@@ -1,6 +1,7 @@
 package project.mogakco.domain.todo.entity;
 
 import lombok.*;
+import project.mogakco.domain.member.entity.member.MemberSocial;
 import project.mogakco.global.domain.BaseEntity;
 
 import javax.persistence.*;
@@ -17,8 +18,12 @@ public class Category extends BaseEntity {
 	@GeneratedValue(strategy = GenerationType.IDENTITY)
 	private Long category_seq;
 
-	private String category_name;
+	private String categoryName;
 
 	@OneToMany(fetch = FetchType.LAZY,mappedBy = "category",cascade = CascadeType.ALL)
 	private List<ToDo> toDo;
+
+	@ManyToOne(fetch = FetchType.LAZY)
+	@JoinColumn(name = "member_seq")
+	private MemberSocial memberSocial;
 }

--- a/mogakco/src/main/java/project/mogakco/domain/todo/entity/Category.java
+++ b/mogakco/src/main/java/project/mogakco/domain/todo/entity/Category.java
@@ -26,4 +26,9 @@ public class Category extends BaseEntity {
 	@ManyToOne(fetch = FetchType.LAZY)
 	@JoinColumn(name = "member_seq")
 	private MemberSocial memberSocial;
+
+	public Category changeCategoryName(String categoryName){
+		this.categoryName=categoryName;
+		return this;
+	}
 }

--- a/mogakco/src/main/java/project/mogakco/domain/todo/entity/Category.java
+++ b/mogakco/src/main/java/project/mogakco/domain/todo/entity/Category.java
@@ -1,0 +1,24 @@
+package project.mogakco.domain.todo.entity;
+
+import lombok.*;
+import project.mogakco.global.domain.BaseEntity;
+
+import javax.persistence.*;
+import java.util.List;
+
+@Entity
+@NoArgsConstructor
+@AllArgsConstructor(access = AccessLevel.PROTECTED)
+@Getter
+@Builder
+public class Category extends BaseEntity {
+
+	@Id
+	@GeneratedValue(strategy = GenerationType.IDENTITY)
+	private Long category_seq;
+
+	private String category_name;
+
+	@OneToMany(fetch = FetchType.LAZY,mappedBy = "category",cascade = CascadeType.ALL)
+	private List<ToDo> toDo;
+}

--- a/mogakco/src/main/java/project/mogakco/domain/todo/entity/ToDo.java
+++ b/mogakco/src/main/java/project/mogakco/domain/todo/entity/ToDo.java
@@ -19,7 +19,7 @@ public class ToDo extends BaseEntity {
 
 	private String todo_title;
 
-	private String todo_text;
+	private String todo_contents;
 
 	@ManyToOne(fetch = FetchType.LAZY)
 	@JoinColumn(name = "category_seq")
@@ -28,4 +28,9 @@ public class ToDo extends BaseEntity {
 	@ManyToOne(fetch = FetchType.LAZY)
 	@JoinColumn(name = "member_seq")
 	private MemberSocial memberSocial;
+
+	public ToDo writeContents(String todo_contents){
+		this.todo_contents=todo_contents;
+		return this;
+	}
 }

--- a/mogakco/src/main/java/project/mogakco/domain/todo/entity/ToDo.java
+++ b/mogakco/src/main/java/project/mogakco/domain/todo/entity/ToDo.java
@@ -17,7 +17,7 @@ public class ToDo extends BaseEntity {
 	@GeneratedValue(strategy = GenerationType.IDENTITY)
 	private Long todoSeq;
 
-	private String todo_title;
+	private String todoTitle;
 
 	private String todo_contents;
 
@@ -31,6 +31,11 @@ public class ToDo extends BaseEntity {
 
 	public ToDo writeContents(String todo_contents){
 		this.todo_contents=todo_contents;
+		return this;
+	}
+
+	public ToDo changeTitleTodo(String todoTitle){
+		this.todoTitle =todoTitle;
 		return this;
 	}
 }

--- a/mogakco/src/main/java/project/mogakco/domain/todo/entity/ToDo.java
+++ b/mogakco/src/main/java/project/mogakco/domain/todo/entity/ToDo.java
@@ -1,0 +1,26 @@
+package project.mogakco.domain.todo.entity;
+
+import lombok.*;
+import project.mogakco.global.domain.BaseEntity;
+
+import javax.persistence.*;
+
+@Entity
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor(access = AccessLevel.PROTECTED)
+@Builder
+public class ToDo extends BaseEntity {
+
+	@Id
+	@GeneratedValue(strategy = GenerationType.IDENTITY)
+	private Long todo_seq;
+
+	private String todo_title;
+
+	private String todo_text;
+
+	@ManyToOne(fetch = FetchType.LAZY)
+	@JoinColumn(name = "category_seq")
+	private Category category;
+}

--- a/mogakco/src/main/java/project/mogakco/domain/todo/entity/ToDo.java
+++ b/mogakco/src/main/java/project/mogakco/domain/todo/entity/ToDo.java
@@ -15,7 +15,7 @@ public class ToDo extends BaseEntity {
 
 	@Id
 	@GeneratedValue(strategy = GenerationType.IDENTITY)
-	private Long todo_seq;
+	private Long todoSeq;
 
 	private String todo_title;
 

--- a/mogakco/src/main/java/project/mogakco/domain/todo/entity/ToDo.java
+++ b/mogakco/src/main/java/project/mogakco/domain/todo/entity/ToDo.java
@@ -1,6 +1,7 @@
 package project.mogakco.domain.todo.entity;
 
 import lombok.*;
+import project.mogakco.domain.member.entity.member.MemberSocial;
 import project.mogakco.global.domain.BaseEntity;
 
 import javax.persistence.*;
@@ -23,4 +24,8 @@ public class ToDo extends BaseEntity {
 	@ManyToOne(fetch = FetchType.LAZY)
 	@JoinColumn(name = "category_seq")
 	private Category category;
+
+	@ManyToOne(fetch = FetchType.LAZY)
+	@JoinColumn(name = "member_seq")
+	private MemberSocial memberSocial;
 }

--- a/mogakco/src/main/java/project/mogakco/domain/todo/repo/CategoryQueryRepository.java
+++ b/mogakco/src/main/java/project/mogakco/domain/todo/repo/CategoryQueryRepository.java
@@ -1,0 +1,15 @@
+package project.mogakco.domain.todo.repo;
+
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Repository;
+
+@RequiredArgsConstructor
+@Repository
+public class CategoryQueryRepository {
+	private final JPAQueryFactory queryFactory;
+
+	public void createCategoryByOauthIdAndName(){
+
+	}
+}

--- a/mogakco/src/main/java/project/mogakco/domain/todo/repo/CategoryRepository.java
+++ b/mogakco/src/main/java/project/mogakco/domain/todo/repo/CategoryRepository.java
@@ -1,10 +1,12 @@
 package project.mogakco.domain.todo.repo;
 
 import org.springframework.data.jpa.repository.JpaRepository;
+import project.mogakco.domain.member.entity.member.MemberSocial;
 import project.mogakco.domain.todo.entity.Category;
 
 import java.util.Optional;
 
 public interface CategoryRepository extends JpaRepository<Category,Long> {
-	Optional<Category> findByCategory_name(String category_name);
+	Optional<Category> findByCategoryName(String categoryName);
+	Optional<Category> findByCategoryNameAndMemberSocial(String category_name, MemberSocial memberSocial);
 }

--- a/mogakco/src/main/java/project/mogakco/domain/todo/repo/CategoryRepository.java
+++ b/mogakco/src/main/java/project/mogakco/domain/todo/repo/CategoryRepository.java
@@ -1,0 +1,10 @@
+package project.mogakco.domain.todo.repo;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import project.mogakco.domain.todo.entity.Category;
+
+import java.util.Optional;
+
+public interface CategoryRepository extends JpaRepository<Category,Long> {
+	Optional<Category> findByCategory_name(String category_name);
+}

--- a/mogakco/src/main/java/project/mogakco/domain/todo/repo/ToDoRepository.java
+++ b/mogakco/src/main/java/project/mogakco/domain/todo/repo/ToDoRepository.java
@@ -1,7 +1,11 @@
 package project.mogakco.domain.todo.repo;
 
 import org.springframework.data.jpa.repository.JpaRepository;
+import project.mogakco.domain.member.entity.member.MemberSocial;
 import project.mogakco.domain.todo.entity.ToDo;
 
+import java.util.Optional;
+
 public interface ToDoRepository extends JpaRepository<ToDo,Long> {
+	Optional<ToDo> findByTodoSeqAndMemberSocial(Long todoSeq, MemberSocial memberSocial);
 }

--- a/mogakco/src/main/java/project/mogakco/domain/todo/repo/ToDoRepository.java
+++ b/mogakco/src/main/java/project/mogakco/domain/todo/repo/ToDoRepository.java
@@ -1,0 +1,7 @@
+package project.mogakco.domain.todo.repo;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import project.mogakco.domain.todo.entity.ToDo;
+
+public interface ToDoRepository extends JpaRepository<ToDo,Long> {
+}

--- a/mogakco/src/main/java/project/mogakco/global/config/JPAConfig.java
+++ b/mogakco/src/main/java/project/mogakco/global/config/JPAConfig.java
@@ -1,0 +1,19 @@
+package project.mogakco.global.config;
+
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+import javax.persistence.EntityManager;
+import javax.persistence.PersistenceContext;
+
+@Configuration
+public class JPAConfig {
+	@PersistenceContext
+	private EntityManager entityManager;
+
+	@Bean
+	public JPAQueryFactory jpaQueryFactory(){
+		return new JPAQueryFactory(entityManager);
+	}
+}

--- a/mogakco/src/main/java/project/mogakco/global/dto/requset/MemberInfoDTO.java
+++ b/mogakco/src/main/java/project/mogakco/global/dto/requset/MemberInfoDTO.java
@@ -1,0 +1,14 @@
+package project.mogakco.global.dto.requset;
+
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+public class MemberInfoDTO {
+
+	@Getter
+	public static class selectInfoByoauthIdDTO{
+		private String oauthId;
+	}
+}


### PR DESCRIPTION
## PR 타입 (하나 이상의 PR 타입 선택)
- [X] 기능 추가
- [] 기능 수정
- [] 기능 삭제
- [] 버그 수정
- [] 의존성, 환경 변수, 빌드 관련 코드 업데이트
- [] 배포환경
- [] 문서 수정 (ex. README)

## 반영 브랜치
- feat/todo -> Dev

## 변경 사항
- ToDo Entity 및 Category Entity에 대한 CRUD 제작
- 개발 완료로 인한 PR

## 유의 사항
- 쿼리의 속도 테스트를 위해 카테고리에서는  `name`과 `Member Entity`정보로 쿼리를 날림
- 반면 투두에서는 고유 값인 `Seq`와 `Member Entity`정보로 쿼리를 날림